### PR TITLE
Add metadata retries

### DIFF
--- a/SPTInstaller/CustomControls/Dialogs/WhyCacheThoughDialog.axaml.cs
+++ b/SPTInstaller/CustomControls/Dialogs/WhyCacheThoughDialog.axaml.cs
@@ -59,39 +59,8 @@ public partial class WhyCacheThoughDialog : UserControl
     
     public void ClearCachedMetaData()
     {
-        var cachedMetadata =
-            new DirectoryInfo(DownloadCacheHelper.CachePath).GetFiles("*.json", SearchOption.TopDirectoryOnly);
-        
-        var message = "no cached metadata to remove";
-        
-        if (cachedMetadata.Length == 0)
-        {
-            AdditionalInfo = message;
-            AdditionalInfoColor = "dodgerblue";
-            Log.Information(message);
-            return;
-        }
-        
-        var allDeleted = true;
-        
-        foreach (var file in cachedMetadata)
-        {
-            try
-            {
-                file.Delete();
-                file.Refresh();
-                if (file.Exists)
-                {
-                    allDeleted = false;
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, $"Failed to delete cached metadata file: {file.Name}");
-            }
-        }
-        
-        message = allDeleted ? "cached metadata removed" : "some files could not be removed. Check logs";
+        var allDeleted = DownloadCacheHelper.ClearMetadataCache();
+        var message =  allDeleted ? "cached metadata removed" : "some files could not be removed. Check logs";
         AdditionalInfo = message;
         AdditionalInfoColor = allDeleted ? "green" : "red";
         Log.Information(message);

--- a/SPTInstaller/Helpers/DownloadCacheHelper.cs
+++ b/SPTInstaller/Helpers/DownloadCacheHelper.cs
@@ -42,6 +42,26 @@ public static class DownloadCacheHelper
         
         return DirectorySizeHelper.SizeSuffix(cacheSize);
     }
+
+
+    public static bool ClearMetadataCache()
+    {
+        var metaData = new DirectoryInfo(CachePath).GetFiles("*.json", SearchOption.TopDirectoryOnly);
+        var allDeleted = true;
+
+        foreach (var file in metaData)
+        {
+            file.Delete();
+            file.Refresh();
+
+            if (file.Exists)
+            {
+                allDeleted = false;
+            }
+        }
+        
+        return allDeleted;
+    }
     
     /// <summary>
     /// Check if a file in the cache already exists

--- a/SPTInstaller/Installer Tasks/ReleaseCheckTask.cs
+++ b/SPTInstaller/Installer Tasks/ReleaseCheckTask.cs
@@ -33,9 +33,6 @@ public class ReleaseCheckTask : InstallerTaskBase
                 return Result.FromError("Failed to download release metadata, try clicking the 'Whats this' button below followed by the 'Clear Metadata cache' button");
             }
             
-            var SPTReleaseInfo =
-                JsonConvert.DeserializeObject<ReleaseInfo>(File.ReadAllText(SPTReleaseInfoFile.FullName));
-            
             SetStatus("Checking for Patches", "", null, ProgressStyle.Indeterminate);
             
             var SPTPatchMirrorsFile =
@@ -46,13 +43,20 @@ public class ReleaseCheckTask : InstallerTaskBase
             {
                 return Result.FromError("Failed to download patch mirror data, try clicking the 'Whats this' button below followed by the 'Clear Metadata cache' button");
             }
+
+            ReleaseInfo? SPTReleaseInfo;
+            PatchInfo? patchMirrorInfo;
             
-            var patchMirrorInfo =
-                JsonConvert.DeserializeObject<PatchInfo>(File.ReadAllText(SPTPatchMirrorsFile.FullName));
-            
-            if (SPTReleaseInfo == null || patchMirrorInfo == null)
+            try
             {
-                return Result.FromError("An error occurred while deserializing SPT or patch data, try clicking the 'Whats this' button below followed by the 'Clear Metadata cache' button");
+                SPTReleaseInfo = JsonConvert.DeserializeObject<ReleaseInfo>(File.ReadAllText(SPTReleaseInfoFile.FullName));
+                
+                patchMirrorInfo =
+                    JsonConvert.DeserializeObject<PatchInfo>(File.ReadAllText(SPTPatchMirrorsFile.FullName));
+            }
+            catch (Exception ex)
+            {
+                return Result.FromError($"An error occurred while deserializing SPT or patch data, try clicking the 'Whats this' button below followed by the 'Clear Metadata cache' button.\n\nERROR: {ex.Message}");
             }
             
             _data.ReleaseInfo = SPTReleaseInfo;

--- a/SPTInstaller/SPTInstaller.csproj
+++ b/SPTInstaller/SPTInstaller.csproj
@@ -10,8 +10,8 @@
         <PackageIcon>icon.ico</PackageIcon>
         <ApplicationIcon>Assets\spt_installer.ico</ApplicationIcon>
         <Configurations>Debug;Release;TEST</Configurations>
-        <AssemblyVersion>2.94</AssemblyVersion>
-        <FileVersion>2.94</FileVersion>
+        <AssemblyVersion>2.95</AssemblyVersion>
+        <FileVersion>2.95</FileVersion>
         <Company>SPT</Company>
     </PropertyGroup>
 

--- a/SPTInstaller/SPTInstaller.csproj
+++ b/SPTInstaller/SPTInstaller.csproj
@@ -10,8 +10,8 @@
         <PackageIcon>icon.ico</PackageIcon>
         <ApplicationIcon>Assets\spt_installer.ico</ApplicationIcon>
         <Configurations>Debug;Release;TEST</Configurations>
-        <AssemblyVersion>2.95</AssemblyVersion>
-        <FileVersion>2.95</FileVersion>
+        <AssemblyVersion>2.96</AssemblyVersion>
+        <FileVersion>2.96</FileVersion>
         <Company>SPT</Company>
     </PropertyGroup>
 


### PR DESCRIPTION
This adds a simple retry mechanism to the metadata downloads / de-serialization in the release checks task and the install buttons initial release check

It also re-words some message in the release checks task